### PR TITLE
feat: optimize the return result when it fails.

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -42,7 +42,8 @@ export interface FetchConfig<R, P extends any[]> {
 
   debounceInterval?: number;
   throttleInterval?: number;
-
+  
+  initialData?: R;
 }
 
 export interface BaseResult<R, P extends any[]> extends FetchResult<R, P> {

--- a/src/useAsync.ts
+++ b/src/useAsync.ts
@@ -135,7 +135,7 @@ class Fetch<R, P extends any[]> {
           clearTimeout(this.loadingDelayTimer);
         }
         this.setState({
-          data: undefined,
+          data: this.config.initialData || undefined,
           error,
           loading: false
         });
@@ -293,7 +293,8 @@ function useAsync<R, P extends any[], U, UU extends U = any>(
     refreshOnWindowFocus,
     focusTimespan,
     debounceInterval,
-    throttleInterval
+    throttleInterval,
+    initialData,
   }
 
 


### PR DESCRIPTION
请求失败时，如果有`initialData`参数，返回结果优先使用`initialData`，而不是`undefined`。